### PR TITLE
use prettier as vscode formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": false,
+  "prettier.configPath": ".prettierrc.json"
+}


### PR DESCRIPTION
Developers should install the vscode plugin `Prettier - Code formatter`, with this config and the plugin we'll always format code on save, and we can add additional formatting rules if needed.